### PR TITLE
Rewrite llms.txt as standalone consumer usage guide

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -23,7 +23,7 @@ Installation:
 
 Basic setup:
 
-```js
+```ts
 import { initializeApp } from 'firebase/app'
 
 const app = initializeApp({
@@ -33,13 +33,15 @@ const app = initializeApp({
 
 FireModel (simple CRUD for a single document):
 
-```js
+```ts
 import { FireModel } from 'nextbone-firestore'
 import { collection, getFirestore } from 'firebase/firestore'
 
 const db = getFirestore()
 
-class User extends FireModel {
+type UserAttrs = { id?: string; name: string; email: string }
+
+class User extends FireModel<UserAttrs> {
   collectionRef() {
     return collection(db, 'users')
   }
@@ -59,11 +61,14 @@ await existingUser.destroy()
 
 ObservableModel (real-time sync for a single document):
 
-```js
+```ts
 import { ObservableModel } from 'nextbone-firestore'
 
-class LiveUser extends ObservableModel {
-  path(params) {
+type UserParams = { orgId?: string; userId?: string }
+type UserAttrs = { id?: string; name?: string }
+
+class LiveUser extends ObservableModel<UserAttrs, UserParams> {
+  path(params: UserParams) {
     if (params.orgId && params.userId) {
       return `organizations/${params.orgId}/users/${params.userId}`
     }
@@ -84,12 +89,15 @@ user.unobserve()
 
 ObservableModel with collection queries (select a snapshot from a query):
 
-```js
+```ts
 import { ObservableModel } from 'nextbone-firestore'
 import { query, where, orderBy, limit } from 'firebase/firestore'
 
-class BaseSynchronization extends ObservableModel {
-  collectionPath(params) {
+type SyncParams = { orgId?: string }
+type SyncAttrs = { id?: string; status?: string; timestamp?: number }
+
+class BaseSynchronization extends ObservableModel<SyncAttrs, SyncParams> {
+  collectionPath(params: SyncParams) {
     return `organizations/${params.orgId}/synchronizations`
   }
 
@@ -114,16 +122,19 @@ class PreviousSynchronization extends BaseSynchronization {
 
 FireCollection (manage multiple documents with optional real-time sync):
 
-```js
+```ts
 import { FireCollection } from 'nextbone-firestore'
 import { query, where, orderBy } from 'firebase/firestore'
 
-class Patients extends FireCollection {
-  path(params) {
+type PatientAttrs = { id?: string; name: string; active: boolean }
+type PatientsParams = { clinicId?: string; includeInactive?: boolean }
+
+class Patients extends FireCollection<PatientAttrs, PatientsParams> {
+  path(params: PatientsParams) {
     return `clinics/${params.clinicId}/patients`
   }
 
-  query(ref, params) {
+  query(ref, params: PatientsParams) {
     let q = ref
     if (!params.includeInactive) {
       q = query(q, where('active', '==', true))
@@ -133,31 +144,41 @@ class Patients extends FireCollection {
 }
 
 const patients = new Patients()
-patients.params.clinicId = 'clinic-1'
+patients.params.clinicId = 'clinic-123'
 
+// Use fetch() for a one-time load without real-time updates.
 await patients.fetch()
 
+// Use observe() to keep the collection synchronized in real time.
 patients.observe()
+console.log(patients.isLoading === true)
 await patients.ready()
+console.log(patients.isLoading === false)
 
 patients.forEach((patient) => {
   console.log(patient.get('name'))
 })
+
+// Changing params triggers automatic re-fetch while observing.
+patients.params.includeInactive = true
+await patients.ready()
 
 patients.unobserve()
 ```
 
 Custom Firestore converters (transform data on read/write):
 
-```js
+```ts
 import { FireCollection, ObservableModel } from 'nextbone-firestore'
 import { Timestamp } from 'firebase/firestore'
 
+type UserAttrs = { id?: string; name: string; createdAt?: Date; updatedAt?: Date }
+
 const userConverter = {
-  toFirestore(data) {
+  toFirestore(data: UserAttrs) {
     return {
       ...data,
-      createdAt: Timestamp.fromDate(data.createdAt),
+      createdAt: Timestamp.fromDate(data.createdAt ?? new Date()),
       updatedAt: Timestamp.now(),
     }
   },
@@ -171,7 +192,7 @@ const userConverter = {
   },
 }
 
-class Users extends FireCollection {
+class Users extends FireCollection<UserAttrs, Record<string, never>> {
   static converter = userConverter
 
   path() {
@@ -179,7 +200,7 @@ class Users extends FireCollection {
   }
 }
 
-class LiveUser extends ObservableModel {
+class LiveUser extends ObservableModel<UserAttrs, Record<string, never>> {
   static converter = userConverter
 
   collectionPath() {

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,195 @@
+# nextbone-firestore
+
+> nextbone-firestore is a Nextbone binding for Firebase Firestore (modular v9+ SDK) that provides FireModel, ObservableModel, and FireCollection classes for CRUD and real-time synchronization.
+
+Use this document as a standalone guide for consuming the package. It summarizes the main features and shows how to use them in code.
+
+Key features:
+
+- Fetch data on demand or listen for real-time updates.
+- Bind to Firestore documents or collections with reactive params.
+- Support custom Firestore converters for data transformations.
+- TypeScript typings included.
+
+Requirements:
+
+- Firebase Web SDK v9+ (modular API).
+- Nextbone.
+
+Installation:
+
+- npm: `npm install nextbone-firestore nextbone firebase`
+- yarn: `yarn add nextbone-firestore nextbone firebase`
+
+Basic setup:
+
+```js
+import { initializeApp } from 'firebase/app'
+
+const app = initializeApp({
+  // your firebase config
+})
+```
+
+FireModel (simple CRUD for a single document):
+
+```js
+import { FireModel } from 'nextbone-firestore'
+import { collection, getFirestore } from 'firebase/firestore'
+
+const db = getFirestore()
+
+class User extends FireModel {
+  collectionRef() {
+    return collection(db, 'users')
+  }
+}
+
+const user = new User({ name: 'John', email: 'john@example.com' })
+await user.save()
+
+const existingUser = new User({ id: 'user-123' })
+await existingUser.fetch()
+
+existingUser.set('name', 'Jane')
+await existingUser.save()
+
+await existingUser.destroy()
+```
+
+ObservableModel (real-time sync for a single document):
+
+```js
+import { ObservableModel } from 'nextbone-firestore'
+
+class LiveUser extends ObservableModel {
+  path(params) {
+    if (params.orgId && params.userId) {
+      return `organizations/${params.orgId}/users/${params.userId}`
+    }
+  }
+}
+
+const user = new LiveUser()
+user.params.orgId = 'org-123'
+user.params.userId = 'user-456'
+
+user.observe()
+await user.ready()
+
+console.log(user.attributes)
+
+user.unobserve()
+```
+
+ObservableModel with collection queries (select a snapshot from a query):
+
+```js
+import { ObservableModel } from 'nextbone-firestore'
+import { query, where, orderBy, limit } from 'firebase/firestore'
+
+class BaseSynchronization extends ObservableModel {
+  collectionPath(params) {
+    return `organizations/${params.orgId}/synchronizations`
+  }
+
+  query(ref) {
+    return query(
+      ref,
+      where('status', '==', 'completed'),
+      orderBy('timestamp', 'desc'),
+      limit(2)
+    )
+  }
+}
+
+class LastSynchronization extends BaseSynchronization {}
+
+class PreviousSynchronization extends BaseSynchronization {
+  selectSnapshot(snapshot) {
+    return snapshot.docs[1]
+  }
+}
+```
+
+FireCollection (manage multiple documents with optional real-time sync):
+
+```js
+import { FireCollection } from 'nextbone-firestore'
+import { query, where, orderBy } from 'firebase/firestore'
+
+class Patients extends FireCollection {
+  path(params) {
+    return `clinics/${params.clinicId}/patients`
+  }
+
+  query(ref, params) {
+    let q = ref
+    if (!params.includeInactive) {
+      q = query(q, where('active', '==', true))
+    }
+    return query(q, orderBy('name'))
+  }
+}
+
+const patients = new Patients()
+patients.params.clinicId = 'clinic-1'
+
+await patients.fetch()
+
+patients.observe()
+await patients.ready()
+
+patients.forEach((patient) => {
+  console.log(patient.get('name'))
+})
+
+patients.unobserve()
+```
+
+Custom Firestore converters (transform data on read/write):
+
+```js
+import { FireCollection, ObservableModel } from 'nextbone-firestore'
+import { Timestamp } from 'firebase/firestore'
+
+const userConverter = {
+  toFirestore(data) {
+    return {
+      ...data,
+      createdAt: Timestamp.fromDate(data.createdAt),
+      updatedAt: Timestamp.now(),
+    }
+  },
+  fromFirestore(snapshot, options) {
+    const data = snapshot.data(options)
+    return {
+      ...data,
+      createdAt: data.createdAt?.toDate(),
+      updatedAt: data.updatedAt?.toDate(),
+    }
+  },
+}
+
+class Users extends FireCollection {
+  static converter = userConverter
+
+  path() {
+    return 'users'
+  }
+}
+
+class LiveUser extends ObservableModel {
+  static converter = userConverter
+
+  collectionPath() {
+    return 'users'
+  }
+}
+```
+
+Class overview:
+
+- `FireModel`: Simple CRUD for a single document (no real-time sync).
+- `ObservableModel`: Real-time synchronization for a single document or a selected document from a query.
+- `FireCollection`: Manage multiple documents with querying and optional real-time sync.

--- a/llms.txt
+++ b/llms.txt
@@ -98,6 +98,10 @@ type SyncAttrs = { id?: string; status?: string; timestamp?: number }
 
 class BaseSynchronization extends ObservableModel<SyncAttrs, SyncParams> {
   collectionPath(params: SyncParams) {
+    if (!params.orgId) {
+      // Returning undefined results in an empty collection.
+      return
+    }
     return `organizations/${params.orgId}/synchronizations`
   }
 
@@ -131,6 +135,10 @@ type PatientsParams = { clinicId?: string; includeInactive?: boolean }
 
 class Patients extends FireCollection<PatientAttrs, PatientsParams> {
   path(params: PatientsParams) {
+    if (!params.clinicId) {
+      // Returning undefined results in an empty collection.
+      return
+    }
     return `clinics/${params.clinicId}/patients`
   }
 

--- a/llms.txt
+++ b/llms.txt
@@ -99,7 +99,7 @@ type SyncAttrs = { id?: string; status?: string; timestamp?: number }
 class BaseSynchronization extends ObservableModel<SyncAttrs, SyncParams> {
   collectionPath(params: SyncParams) {
     if (!params.orgId) {
-      // Returning undefined results in an empty collection.
+      // Returning undefined results in an empty model.
       return
     }
     return `organizations/${params.orgId}/synchronizations`


### PR DESCRIPTION
### Motivation

- Provide a standalone `llms.txt` intended for package consumers rather than repository maintainers. 
- Summarize the library features and usage patterns with inline examples demonstrating the main features. 
- Avoid linking to repository files so the document can be used without repository context. 
- Replace previous AI/developer-focused guidance with concrete consumer-facing instructions and examples.

### Description

- Replaced the previous `llms.txt` content with a full consumer guide that includes an overview, requirements, installation, and basic setup using `initializeApp`.
- Added inline usage examples for `FireModel`, `ObservableModel`, `FireCollection`, and custom Firestore converters showing common patterns and API usage. 
- Removed repository-specific notes and file links so all necessary information is embedded in the file itself. 
- Saved the revised `llms.txt` with ~195 lines of content covering feature highlights, examples, and a class overview.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695d039655dc833092ed0e98ef6c5861)